### PR TITLE
FIX: Resolve TypeError: The "chunk" argument must be of type string or an instance of Buffer or Uint8Array #2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,23 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [Unreleased]
 
 - Initial release
+
+## [0.0.3] 15-03-2023
+
+### Added
+
+- CONTRIBUTING.md (#6)
+
+### Fixed
+
+- Improved interal stream management (#2)
+
+## [0.0.2] 11-03-2023
+
+### Fixed
+
+- Added a dependency to installation guide (#1)
+
+## [0.0.1] 10-03-2023
+
+- Initial release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "terraform-live-graph",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "terraform-live-graph",
-      "version": "0.0.1",
+      "version": "0.0.3",
+      "license": "MIT",
       "dependencies": {
         "ts-graphviz": "^1.5.5"
       },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "terraform-live-graph",
   "displayName": "Terraform Live Graph",
   "description": "The Terraform Live Graph Extension for Visual Studio Code is a plugin that allows you to generate a live Terraform graph as you code. This extension makes it easy to visualize your infrastructure and the relationships between resources, helping you to understand how your infrastructure is configured.",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "engines": {
     "vscode": "^1.76.0"
   },

--- a/src/vscodeTerrafromGraph.ts
+++ b/src/vscodeTerrafromGraph.ts
@@ -69,13 +69,12 @@ export default class VSCodeTerraformGraph {
       }
     }
 
-    private static async streamToString(stream: NodeJS.ReadableStream): Promise<string> {
-      const chunks: Array<any> = []
-      return new Promise((resolve, reject) => {
-        stream.on('data', chunk => chunks.push(chunk))
-        stream.on('error', reject)
-        stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
-      })
-    }
+    private static async streamToString(stream: NodeJS.ReadableStream) {
+      const chunks: Uint8Array[] = [];
+      for await (const chunk of stream) {
+          chunks.push(Buffer.from(chunk));
+      }
+      return Buffer.concat(chunks).toString("utf-8");
+  }
 }
 


### PR DESCRIPTION
Context: #2 
After some looking into the issue, it seems like there is some kind of unexpected behavior when the extension converts the stream to a string. I tried to alter the implementation and explicitly add typing along with implementation according to language improvements in Node.js that allow a cleaner function.